### PR TITLE
Fixed typo in writing SoundFontSample struct

### DIFF
--- a/lib/AudioConvert.c
+++ b/lib/AudioConvert.c
@@ -873,8 +873,8 @@ void Audio_SaveSample_VadpcmC(AudioSampleInfo* sampleInfo) {
 		"	.loop      = &%sLoop,\n"
 		"	.book      = &%sBook,\n"
 		"};\n\n",
-		gPrecisionFlag,
 		basename,
+		gPrecisionFlag,
 		sampleInfo->size,
 		basename,
 		basename


### PR DESCRIPTION
`basename` and `gPrecisionFlag` were accidentally swapped, leading to corrupted C output.